### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/SimpleTCS3200/keywords.txt
+++ b/SimpleTCS3200/keywords.txt
@@ -1,5 +1,5 @@
 SimpleTCS3200	KEYWORD1
-translateColour KEYWORD1
+translateColour	KEYWORD1
 readColour	KEYWORD2
 whatColour	KEYWORD2
 calibrar	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords